### PR TITLE
Event Stream Example: Update to use event stream release 0.6.0

### DIFF
--- a/event-stream-example/gradle/libs.versions.toml
+++ b/event-stream-example/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-provenanceEventStream = "0.6.0-rc7"
+provenanceEventStream = "0.6.0"
 kotlinCoroutines = "1.5.2"
 scarlet = "0.1.12"
 kafka = "3.1.0"

--- a/event-stream-example/settings.gradle.kts
+++ b/event-stream-example/settings.gradle.kts
@@ -4,6 +4,5 @@ rootProject.name = "event-stream-example"
 dependencyResolutionManagement {
     repositories {
         mavenCentral()
-        maven { url = uri("https://s01.oss.sonatype.org/content/groups/staging/") }
     }
 }


### PR DESCRIPTION
Event stream release `0.6.0` is now stable and live, allowing this example to move away from release candidates and showcase the real deal