### PR TITLE
Bilateral Exchange: Add MsgFees example

### DIFF
--- a/bilateral-trade-example/Cargo.lock
+++ b/bilateral-trade-example/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "3bdca834647821e0b13d9539a8634eb62d3501b6b6c2cec1722786ee6671b851"
 
 [[package]]
 name = "bilateral-trade-example"
-version = "1.0.0-beta"
+version = "1.1.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -376,9 +376,9 @@ dependencies = [
 
 [[package]]
 name = "provwasm-mocks"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d50a6b2160bfd9be6f31b6460a8d0a2a5e46bb2c5ef84299b91573760f6699f"
+checksum = "b90b0dc19138397cabf8050dc4a7ddbb47dc3e7ba5e1a50cae23a014f436c4f1"
 dependencies = [
  "cosmwasm-std",
  "provwasm-std",
@@ -388,9 +388,9 @@ dependencies = [
 
 [[package]]
 name = "provwasm-std"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0e11a20ee310c90a0cd5f903125ed10195b32e725cc08a18a1d3fb3a4caf110"
+checksum = "6af27a7939f7a89df3937d9eb05de442154dc29e51716e5704af2019705b1593"
 dependencies = [
  "cosmwasm-std",
  "schemars",

--- a/bilateral-trade-example/Cargo.toml
+++ b/bilateral-trade-example/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "bilateral-trade-example"
-version = "1.0.0-beta"
+version = "1.1.0"
 authors = ["Ken Talley <ktalley@figure.com>", "Jake Schwartz <jschwartz@figure.com>", "Pierce Trey <ptrey@figure.com>"]
-edition = "2018"
+edition = "2021"
 
 exclude = [
   "bilateral_exchange.wasm",
@@ -30,12 +30,12 @@ overflow-checks = true
 [dependencies]
 cosmwasm-std = { version = "=1.0.0", features = ["staking"] }
 cosmwasm-storage = { version = "=1.0.0" }
-cw-storage-plus = { version = "0.12.1" }
-provwasm-std = { version = "=1.0.0" }
+cw-storage-plus = { version = "=0.12.1" }
+provwasm-std = { version = "=1.1.0" }
 schemars = "=0.8.3"
 serde = { version = "=1.0.137", default-features = false, features = ["derive"] }
 thiserror = { version = "=1.0.26" }
 
 [dev-dependencies]
 cosmwasm-schema = { version = "=1.0.0" }
-provwasm-mocks = { version = "=1.0.0" }
+provwasm-mocks = { version = "=1.1.0" }

--- a/bilateral-trade-example/README.md
+++ b/bilateral-trade-example/README.md
@@ -9,3 +9,151 @@ and then swaps the two to the appropriate parties atomically in one transaction.
 2. [Kotlin Examples](./examples/kotlin/scope-exchange): Each example in this directory is a representation of how to interact with a stored smart contract via Kotlin, using Provenance Blockchain's GRPC [PbClient](https://github.com/provenance-io/pb-grpc-client-kotlin):
    1. [Scope for Coin Exchange](src/main/kotlin/ScopeExchange.kt): Connects to the Provenance Blockchain testnet and trades a [scope](https://docs.provenance.io/modules/metadata-module#scope-data-structures) owned by an [account](https://docs.provenance.io/blockchain/basics/accounts) to another account in exchange for coin.
    2. [Marker-owned Scope exchange via Marker's coin for other coin](examples/kotlin/scope-exchange/src/main/kotlin/MarkerOwnedScopeExchange.kt): An example of trading a [marker](https://docs.provenance.io/modules/marker-module)'s coins for some other coin as a proxy for exchanging scope value
+
+## Message Structure Quick Reference
+Note: Each message is described fully in the [Schema](schema) directory, as well as in the [msg.rs](src/msg.rs) file.
+
+1. _Instantiate_:
+
+```json
+{
+   "bind_name": "somename.sc.pb",
+   "contract_name": "A descriptive name for this contract",
+   "ask_fee": "100",
+   "bid_fee": "250"
+}
+```
+
+2. _Create Ask_:
+
+_Note_: 
+If no scope address is provided, the request must include funds that constitute the `base` that the bidder will
+be matched with in their `coin` variant declaration of the `base` in their message.  
+
+If a scope address is provided, the asker must not provide any funds, and must transfer ownership of a Provenance 
+Blockchain Metadata Scope to the smart contract's bech32 address, setting it as the owner in the scope's `owners` 
+array, as well as the scope's `value_owner_address` value.  It is recommended that this transfer be done in the same
+transaction as the execution of the contract's `create_ask` message, to ensure that the scope does not get transferred
+to the contract with no record of doing so if the contract's validation rejects the `create_ask`.
+
+```json
+{
+   "create_ask": {
+      "id": "my-ask-id",
+      "quote": [{
+         "amount": "150",
+         "denom": "biddercoin"
+      }],
+      "scope_address": "scope1qzrptuwxpht3rmv42ape63wesgfsntxa5h"  
+   }
+}
+```
+
+3. _Create Bid_:
+
+_Coin Variant_: If the asker omitted a scope address and provided `base` funds, then the bidder must choose the `coin`
+variant and provide a coin amount that matches the asker's `base`, as well as funds that match the asker's `quote`.
+
+```json
+{
+   "create_bid": {
+      "id": "my-bid-id",
+      "base": {
+         "coin": {
+            "coins": [{
+               "amount": "200",
+               "denom": "askercoin"
+            }]
+         }
+      },
+      "effective_time": "1658945674349115000"
+   }
+}
+```
+
+_Scope Variant_: If the asker provided a Provenance Blockchain Metadata Scope and no `base` funds, then the bidder must 
+provide funds to constitute the asker's `quote` and directly refer to the scope address required in the trade using the 
+`scope` variant.
+
+```json
+{
+   "create_bid": {
+      "id": "my-bid-id",
+      "base": {
+         "scope": {
+            "scope_address": "scope1qzrptuwxpht3rmv42ape63wesgfsntxa5h"
+         }
+      },
+      "effective_time": "1658945674349115000"
+   }
+}
+```
+
+4. _Execute Match_:
+
+_Note_: Only the contract's admin account may execute matches.
+
+```json
+{
+   "execute_match": {
+      "ask_id": "my-ask-id",
+      "bid_id": "my-bid-id"
+   }
+}
+```
+
+5. _Cancel Ask_: 
+
+```json
+{
+   "cancel_ask": {
+      "ask_id": "my-ask-id"
+   }
+}
+```
+
+6. _Cancel Bid_:
+
+```json
+{
+   "cancel_bid": {
+      "bid_id": "my-bid-id"
+   }
+}
+```
+
+7. _Get Ask_:
+
+```json
+{
+   "get_ask": {
+      "id": "my-ask-id"
+   }
+}
+```
+
+8. _Get Bid_: 
+
+```json
+{
+   "get_bid": {
+      "id": "my-bid-id"
+   }
+}
+```
+
+9. _Get Contract Info_:
+
+```json
+{
+   "get_contract_info": {}
+}
+```
+
+10. _Migrate Contract_:
+
+```json
+{
+   "new_version": {}
+}
+```

--- a/bilateral-trade-example/examples/kotlin/scope-exchange/gradle/libs.versions.toml
+++ b/bilateral-trade-example/examples/kotlin/scope-exchange/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 hdWallet = "0.1.15"
-pbClient = "1.0.5"
-provenance = "1.8.0"
+pbClient = "1.1.1"
+provenance = "1.11.1"
 
 [libraries]
 hdWallet = { module = "io.provenance.hdwallet:hdwallet", version.ref = "hdWallet" }

--- a/bilateral-trade-example/examples/kotlin/scope-exchange/src/main/kotlin/ScopeExchange.kt
+++ b/bilateral-trade-example/examples/kotlin/scope-exchange/src/main/kotlin/ScopeExchange.kt
@@ -16,10 +16,6 @@ import io.provenance.hdwallet.common.hashing.sha256
 import io.provenance.hdwallet.signer.BCECSigner
 import io.provenance.hdwallet.wallet.Account
 import io.provenance.hdwallet.wallet.Wallet
-import io.provenance.metadata.v1.MsgWriteScopeRequest
-import io.provenance.metadata.v1.Party
-import io.provenance.metadata.v1.PartyType
-import io.provenance.metadata.v1.ScopeRequest
 import java.net.URI
 import java.util.UUID
 

--- a/bilateral-trade-example/examples/schema.rs
+++ b/bilateral-trade-example/examples/schema.rs
@@ -3,9 +3,9 @@ use std::fs::create_dir_all;
 
 use cosmwasm_schema::{export_schema, remove_schemas, schema_for};
 
-use bilateral_exchange::contract_info::ContractInfo;
-use bilateral_exchange::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
-use bilateral_exchange::state::{AskOrder, BidOrder};
+use bilateral_trade_example::contract_info::ContractInfo;
+use bilateral_trade_example::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
+use bilateral_trade_example::state::{AskOrder, BidOrder};
 
 fn main() {
     let mut out_dir = current_dir().unwrap();

--- a/bilateral-trade-example/schema/contract_info.json
+++ b/bilateral-trade-example/schema/contract_info.json
@@ -13,6 +13,26 @@
     "admin": {
       "$ref": "#/definitions/Addr"
     },
+    "ask_fee": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Uint128"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "bid_fee": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Uint128"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "bind_name": {
       "type": "string"
     },
@@ -29,6 +49,10 @@
   "definitions": {
     "Addr": {
       "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+      "type": "string"
+    },
+    "Uint128": {
+      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
       "type": "string"
     }
   }

--- a/bilateral-trade-example/schema/execute_msg.json
+++ b/bilateral-trade-example/schema/execute_msg.json
@@ -1,8 +1,10 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "ExecuteMsg",
+  "description": "Executes the smart contract, causing changes reflected in Provenance Blockchain transactions.",
   "anyOf": [
     {
+      "description": "Removes an ask from the contract's storage and refunds the base (Provenance Blockchain Metadata Scope or Coin).  Ask creation fees are not refunded.",
       "type": "object",
       "required": [
         "cancel_ask"
@@ -15,6 +17,7 @@
           ],
           "properties": {
             "id": {
+              "description": "The unique identifier for the ask to cancel.  If no ask with this value exists in contract storage, an error will be returned.",
               "type": "string"
             }
           }
@@ -23,6 +26,7 @@
       "additionalProperties": false
     },
     {
+      "description": "Removes a bid from the contract's storage and refunds the quote funds provided.  Bid creation fees are not refunded.",
       "type": "object",
       "required": [
         "cancel_bid"
@@ -35,6 +39,7 @@
           ],
           "properties": {
             "id": {
+              "description": "The unique identifier for the bid to cancel.  If no bid with this value exists in contract storage, an error will be returned.",
               "type": "string"
             }
           }
@@ -43,6 +48,7 @@
       "additionalProperties": false
     },
     {
+      "description": "Creates a new AskOrder, holding the given base Coin or Provenance Blockchain Metadata Scope in the smart contract until a cancellation occurs or a match is made.",
       "type": "object",
       "required": [
         "create_ask"
@@ -56,15 +62,18 @@
           ],
           "properties": {
             "id": {
+              "description": "The unique identifier for the new ask to create.  If an ask already exists with the given id, an error will be returned.",
               "type": "string"
             },
             "quote": {
+              "description": "The funds that a bidder must provide for a match to be successfully executed.",
               "type": "array",
               "items": {
                 "$ref": "#/definitions/Coin"
               }
             },
             "scope_address": {
+              "description": "The address of a scope to list for trade.  If this value is omitted, funds must be provided in the execute message transaction.",
               "type": [
                 "string",
                 "null"
@@ -76,6 +85,7 @@
       "additionalProperties": false
     },
     {
+      "description": "Creates a new BidOrder, holding the given quote Coin in the smart contract until a cancellation occurs or a match is made.",
       "type": "object",
       "required": [
         "create_bid"
@@ -89,9 +99,15 @@
           ],
           "properties": {
             "base": {
-              "$ref": "#/definitions/BaseType"
+              "description": "Indicates the type of exchange that will be made: scope or coin.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/BaseType"
+                }
+              ]
             },
             "effective_time": {
+              "description": "An optional timestamp denoting when the bid was created.",
               "anyOf": [
                 {
                   "$ref": "#/definitions/Timestamp"
@@ -102,6 +118,7 @@
               ]
             },
             "id": {
+              "description": "The unique identifier for the new bid to create.  If a bid already exists with the given id, an error will be returned.",
               "type": "string"
             }
           }
@@ -110,6 +127,44 @@
       "additionalProperties": false
     },
     {
+      "description": "Changes the contract's fees to the specified values.  Only the contract's admin account can execute this route.",
+      "type": "object",
+      "required": [
+        "update_fees"
+      ],
+      "properties": {
+        "update_fees": {
+          "type": "object",
+          "properties": {
+            "ask_fee": {
+              "description": "The new value to charge the sender when asks are created.  If this value is omitted, the value in contract storage will be cleared.  Providing zero or a negative value will produce an error.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Uint128"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "bid_fee": {
+              "description": "The new value to charge the sender when bids are created.  If this value is omitted, the value in contract storage will be cleared.  Providing zero or a negative value will produce an error.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Uint128"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Attempts to match an AskOrder with a BidOrder, performing an exchange of the asker's base with the bidder's quote.  This will only be successful if the bidder's base matches the asker's base, and the asker's quote matches the bidder's quote.",
       "type": "object",
       "required": [
         "execute_match"
@@ -123,9 +178,11 @@
           ],
           "properties": {
             "ask_id": {
+              "description": "The unique identifier of the ask to attempt a match on.  If no ask exists within the contract storage with this id, an error will be returned.",
               "type": "string"
             },
             "bid_id": {
+              "description": "The unique identifier of the bid to attempt a match on.  If no bid exists within the contract storage with this id, an error will be returned.",
               "type": "string"
             }
           }

--- a/bilateral-trade-example/schema/instantiate_msg.json
+++ b/bilateral-trade-example/schema/instantiate_msg.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "InstantiateMsg",
+  "description": "Constructs a new instance of the smart contract.",
   "type": "object",
   "required": [
     "bind_name",
@@ -8,6 +9,7 @@
   ],
   "properties": {
     "ask_fee": {
+      "description": "An amount to be charged to the sender when an ask is created.  This uses the Provenance Blockchain Fee Module, which will take 50% of the fees sent and redistribute them to various external entities.  The other 50% will be retained and sent to the contract's admin account.",
       "anyOf": [
         {
           "$ref": "#/definitions/Uint128"
@@ -18,6 +20,7 @@
       ]
     },
     "bid_fee": {
+      "description": "An amount to be charged to the sender when a bid is created.  This uses the Provenance Blockchain Fee Module, which will take 50% of the fees sent and redistribute them to various external entities.  The other 50% will be retained and sent to the contract's admin account.",
       "anyOf": [
         {
           "$ref": "#/definitions/Uint128"
@@ -28,9 +31,11 @@
       ]
     },
     "bind_name": {
+      "description": "A name that will be bound to the smart contract using the Provenance Blockchain Name Module. This name must be unrestricted, or a failure will occur.  Note: The Provenance Blockchain provides a parent name, \"sc.pb\" on both testnet and mainnet that is unrestricted, specifically for binding smart contracts on instantiation.",
       "type": "string"
     },
     "contract_name": {
+      "description": "A free-form name for the smart contract, purely for description and display purposes.",
       "type": "string"
     }
   },

--- a/bilateral-trade-example/schema/instantiate_msg.json
+++ b/bilateral-trade-example/schema/instantiate_msg.json
@@ -7,10 +7,36 @@
     "contract_name"
   ],
   "properties": {
+    "ask_fee": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Uint128"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "bid_fee": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Uint128"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "bind_name": {
       "type": "string"
     },
     "contract_name": {
+      "type": "string"
+    }
+  },
+  "definitions": {
+    "Uint128": {
+      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
       "type": "string"
     }
   }

--- a/bilateral-trade-example/schema/query_msg.json
+++ b/bilateral-trade-example/schema/query_msg.json
@@ -1,8 +1,10 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "QueryMsg",
+  "description": "Fetches data from the smart contract.  No query routes make changes to blockchain data.",
   "anyOf": [
     {
+      "description": "Fetches an existing AskOrder from contract storage.",
       "type": "object",
       "required": [
         "get_ask"
@@ -15,6 +17,7 @@
           ],
           "properties": {
             "id": {
+              "description": "The unique identifier of the AskOrder to fetch.  If no order exists in storage for the given id, an error will be returned.",
               "type": "string"
             }
           }
@@ -23,6 +26,7 @@
       "additionalProperties": false
     },
     {
+      "description": "Fetches an existing BidOrder from contract storage.",
       "type": "object",
       "required": [
         "get_bid"
@@ -35,6 +39,7 @@
           ],
           "properties": {
             "id": {
+              "description": "The unique identifier of the BidOrder to fetch.  If no order exists in storage for the given id, an error will be returned.",
               "type": "string"
             }
           }
@@ -43,6 +48,7 @@
       "additionalProperties": false
     },
     {
+      "description": "Fetches the ContractInfo from contract storage.  This value is created as part of the instantiation process, so this query should only ever fail if the blockchain is experiencing downtime.",
       "type": "object",
       "required": [
         "get_contract_info"

--- a/bilateral-trade-example/src/contract_info.rs
+++ b/bilateral-trade-example/src/contract_info.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{Addr, StdResult, Storage};
+use cosmwasm_std::{Addr, StdResult, Storage, Uint128};
 use cw_storage_plus::Item;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -18,16 +18,26 @@ pub struct ContractInfo {
     pub contract_name: String,
     pub contract_type: String,
     pub contract_version: String,
+    pub ask_fee: Option<Uint128>,
+    pub bid_fee: Option<Uint128>,
 }
 
 impl ContractInfo {
-    pub fn new(admin: Addr, bind_name: String, contract_name: String) -> ContractInfo {
+    pub fn new(
+        admin: Addr,
+        bind_name: String,
+        contract_name: String,
+        ask_fee: Option<Uint128>,
+        bid_fee: Option<Uint128>,
+    ) -> ContractInfo {
         ContractInfo {
             admin,
             bind_name,
             contract_name,
             contract_type: CONTRACT_TYPE.into(),
             contract_version: CONTRACT_VERSION.into(),
+            ask_fee,
+            bid_fee,
         }
     }
 }
@@ -51,7 +61,7 @@ mod tests {
     use crate::contract_info::{
         get_contract_info, set_contract_info, ContractInfo, CONTRACT_TYPE, CONTRACT_VERSION,
     };
-    use cosmwasm_std::Addr;
+    use cosmwasm_std::{Addr, Uint128};
 
     #[test]
     pub fn set_contract_info_with_valid_data() {
@@ -62,6 +72,8 @@ mod tests {
                 Addr::unchecked("contract_admin"),
                 "contract_bind_name".into(),
                 "contract_name".into(),
+                Some(Uint128::new(50)),
+                Some(Uint128::new(100)),
             ),
         );
         match result {

--- a/bilateral-trade-example/src/error.rs
+++ b/bilateral-trade-example/src/error.rs
@@ -40,4 +40,7 @@ pub enum ContractError {
 
     #[error("Unauthorized")]
     Unauthorized {},
+
+    #[error("Cannot send funds when updating fees")]
+    UpdateFeesWithFunds {},
 }

--- a/bilateral-trade-example/src/error.rs
+++ b/bilateral-trade-example/src/error.rs
@@ -24,6 +24,11 @@ pub enum ContractError {
         explanation: String,
     },
 
+    #[error(
+        "Invalid {fee_type} fee provided. The value must be omitted, or set to a value above zero"
+    )]
+    InvalidFee { fee_type: String },
+
     #[error("Missing field: {field:?}")]
     MissingField { field: String },
 

--- a/bilateral-trade-example/src/msg.rs
+++ b/bilateral-trade-example/src/msg.rs
@@ -65,6 +65,18 @@ pub enum ExecuteMsg {
         /// An optional timestamp denoting when the bid was created.
         effective_time: Option<Timestamp>,
     },
+    /// Changes the contract's fees to the specified values.  Only the contract's admin account can
+    /// execute this route.
+    UpdateFees {
+        /// The new value to charge the sender when asks are created.  If this value is omitted,
+        /// the value in contract storage will be cleared.  Providing zero or a negative value will
+        /// produce an error.
+        ask_fee: Option<Uint128>,
+        /// The new value to charge the sender when bids are created.  If this value is omitted,
+        /// the value in contract storage will be cleared.  Providing zero or a negative value will
+        /// produce an error.
+        bid_fee: Option<Uint128>,
+    },
     /// Attempts to match an AskOrder with a BidOrder, performing an exchange of the asker's base
     /// with the bidder's quote.  This will only be successful if the bidder's base matches the
     /// asker's base, and the asker's quote matches the bidder's quote.

--- a/bilateral-trade-example/src/msg.rs
+++ b/bilateral-trade-example/src/msg.rs
@@ -4,49 +4,107 @@ use serde::{Deserialize, Serialize};
 
 use crate::state::BaseType;
 
+/// Constructs a new instance of the smart contract.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct InstantiateMsg {
+    /// A name that will be bound to the smart contract using the Provenance Blockchain Name Module.
+    /// This name must be unrestricted, or a failure will occur.  Note: The Provenance Blockchain
+    /// provides a parent name, "sc.pb" on both testnet and mainnet that is unrestricted, specifically
+    /// for binding smart contracts on instantiation.
     pub bind_name: String,
+    /// A free-form name for the smart contract, purely for description and display purposes.
     pub contract_name: String,
+    /// An amount to be charged to the sender when an ask is created.  This uses the Provenance
+    /// Blockchain Fee Module, which will take 50% of the fees sent and redistribute them to various
+    /// external entities.  The other 50% will be retained and sent to the contract's admin account.
     pub ask_fee: Option<Uint128>,
+    /// An amount to be charged to the sender when a bid is created.  This uses the Provenance
+    /// Blockchain Fee Module, which will take 50% of the fees sent and redistribute them to various
+    /// external entities.  The other 50% will be retained and sent to the contract's admin account.
     pub bid_fee: Option<Uint128>,
 }
 
+/// Executes the smart contract, causing changes reflected in Provenance Blockchain transactions.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ExecuteMsg {
+    /// Removes an ask from the contract's storage and refunds the base (Provenance Blockchain
+    /// Metadata Scope or Coin).  Ask creation fees are not refunded.
     CancelAsk {
+        /// The unique identifier for the ask to cancel.  If no ask with this value exists in
+        /// contract storage, an error will be returned.
         id: String,
     },
+    /// Removes a bid from the contract's storage and refunds the quote funds provided.  Bid creation
+    /// fees are not refunded.
     CancelBid {
+        /// The unique identifier for the bid to cancel.  If no bid with this value exists in
+        /// contract storage, an error will be returned.
         id: String,
     },
+    /// Creates a new AskOrder, holding the given base Coin or Provenance Blockchain Metadata Scope
+    /// in the smart contract until a cancellation occurs or a match is made.
     CreateAsk {
+        /// The unique identifier for the new ask to create.  If an ask already exists with the
+        /// given id, an error will be returned.
         id: String,
+        /// The funds that a bidder must provide for a match to be successfully executed.
         quote: Vec<Coin>,
+        /// The address of a scope to list for trade.  If this value is omitted, funds must be
+        /// provided in the execute message transaction.
         scope_address: Option<String>,
     },
+    /// Creates a new BidOrder, holding the given quote Coin in the smart contract until a
+    /// cancellation occurs or a match is made.
     CreateBid {
+        /// The unique identifier for the new bid to create.  If a bid already exists with the
+        /// given id, an error will be returned.
         id: String,
+        /// Indicates the type of exchange that will be made: scope or coin.
         base: BaseType,
+        /// An optional timestamp denoting when the bid was created.
         effective_time: Option<Timestamp>,
     },
+    /// Attempts to match an AskOrder with a BidOrder, performing an exchange of the asker's base
+    /// with the bidder's quote.  This will only be successful if the bidder's base matches the
+    /// asker's base, and the asker's quote matches the bidder's quote.
     ExecuteMatch {
+        /// The unique identifier of the ask to attempt a match on.  If no ask exists within the
+        /// contract storage with this id, an error will be returned.
         ask_id: String,
+        /// The unique identifier of the bid to attempt a match on.  If no bid exists within the
+        /// contract storage with this id, an error will be returned.
         bid_id: String,
     },
 }
 
+/// Fetches data from the smart contract.  No query routes make changes to blockchain data.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum QueryMsg {
-    GetAsk { id: String },
-    GetBid { id: String },
+    /// Fetches an existing AskOrder from contract storage.
+    GetAsk {
+        /// The unique identifier of the AskOrder to fetch.  If no order exists in storage for the
+        /// given id, an error will be returned.
+        id: String,
+    },
+    /// Fetches an existing BidOrder from contract storage.
+    GetBid {
+        ///  The unique identifier of the BidOrder to fetch.  If no order exists in storage for the
+        /// given id, an error will be returned.
+        id: String,
+    },
+    /// Fetches the ContractInfo from contract storage.  This value is created as part of the
+    /// instantiation process, so this query should only ever fail if the blockchain is experiencing
+    /// downtime.
     GetContractInfo {},
 }
 
+/// Migrates the smart contract to a new version of its source code.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum MigrateMsg {
+    /// Overwrites the contract's base code with a new version.  This route will never modify values
+    /// stored in contract storage (like Ask or Bid orders).
     NewVersion {},
 }

--- a/bilateral-trade-example/src/msg.rs
+++ b/bilateral-trade-example/src/msg.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{Coin, Timestamp};
+use cosmwasm_std::{Coin, Timestamp, Uint128};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -8,6 +8,8 @@ use crate::state::BaseType;
 pub struct InstantiateMsg {
     pub bind_name: String,
     pub contract_name: String,
+    pub ask_fee: Option<Uint128>,
+    pub bid_fee: Option<Uint128>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]


### PR DESCRIPTION
This PR adds the new `assess_custom_fee` provenance msg from Provwasm 1.1.0 to the repository, demonstrating how to manage and charge custom fees.  It also adds some quick reference stuff to the readme to assist others in standing up the contract, etc.