### PR TITLE
Upgrade to Figure Tech event stream lib in the event-stream-example

### DIFF
--- a/event-stream-example/build.gradle.kts
+++ b/event-stream-example/build.gradle.kts
@@ -14,6 +14,7 @@ application {
 
 dependencies {
     listOf(
+        libs.bundles.eventstream,
         libs.bundles.provenance,
         libs.bundles.coroutines,
         libs.bundles.kafka,

--- a/event-stream-example/gradle/libs.versions.toml
+++ b/event-stream-example/gradle/libs.versions.toml
@@ -1,16 +1,16 @@
 [versions]
-provenanceEventStream = "0.6.0"
+figureTechEventStream = "0.8.1"
 kotlinCoroutines = "1.5.2"
 scarlet = "0.1.12"
 kafka = "3.1.0"
 kafkaCoroutines = "0.2.0"
 
 [libraries]
-provenanceEventStreamApi = { module = "io.provenance.eventstream:es-api", version.ref = "provenanceEventStream" }
-provenanceEventStreamApiModel = { module = "io.provenance.eventstream:es-api-model", version.ref = "provenanceEventStream" }
-provenanceEventStreamCli = { module = "io.provenance.eventstream:es-cli", version.ref = "provenanceEventStream" }
-provenanceEventStreamCore = { module = "io.provenance.eventstream:es-core", version.ref = "provenanceEventStream" }
-provenanceEventStreamKafka = { module = "io.provenance.eventstream:es-kafka", version.ref = "provenanceEventStream" }
+figureTechEventStreamApi = { module = "tech.figure.eventstream:es-api", version.ref = "figureTechEventStream" }
+figureTechEventStreamApiModel = { module = "tech.figure.eventstream:es-api-model", version.ref = "figureTechEventStream" }
+figureTechEventStreamCli = { module = "tech.figure.eventstream:es-cli", version.ref = "figureTechEventStream" }
+figureTechEventStreamCore = { module = "tech.figure.eventstream:es-core", version.ref = "figureTechEventStream" }
+figureTechEventStreamKafka = { module = "tech.figure.eventstream:es-kafka", version.ref = "figureTechEventStream" }
 webSocketOkHttp = { module = "com.tinder.scarlet:websocket-okhttp", version.ref = "scarlet" }
 messageAdapterMoshi = { module = "com.tinder.scarlet:message-adapter-moshi", version.ref = "scarlet"}
 scarlet = { module = "com.tinder.scarlet:scarlet", version.ref = "scarlet"}
@@ -23,6 +23,7 @@ kafka = { module = "org.apache.kafka:kafka-clients", version.ref = "kafka" }
 kafkaCoroutines = { module = "io.provenance.kafka-coroutine:kafka-coroutines-core", version.ref = "kafkaCoroutines" }
 
 [bundles]
-provenance = ["provenanceEventStreamApi", "provenanceEventStreamApiModel", "provenanceEventStreamCli", "provenanceEventStreamCore", "provenanceEventStreamKafka", "webSocketOkHttp", "messageAdapterMoshi", "scarlet", "streamAdapterCoroutines"]
+eventstream = ["figureTechEventStreamApi", "figureTechEventStreamApiModel", "figureTechEventStreamCli", "figureTechEventStreamCore", "figureTechEventStreamKafka"]
+provenance = ["webSocketOkHttp", "messageAdapterMoshi", "scarlet", "streamAdapterCoroutines"]
 coroutines = ["coroutinesCoreJvm","coroutinesReactor","coroutinesJdk8","coroutinesSLF4J"]
 kafka = ["kafka", "kafkaCoroutines"]

--- a/event-stream-example/src/main/kotlin/io/provenance/example/KafkaConsumerExample.kt
+++ b/event-stream-example/src/main/kotlin/io/provenance/example/KafkaConsumerExample.kt
@@ -1,18 +1,5 @@
 package io.provenance.example
 
-import io.provenance.eventstream.decoder.moshiDecoderAdapter
-import io.provenance.eventstream.extensions.decodeBase64
-import io.provenance.eventstream.net.okHttpNetAdapter
-import io.provenance.eventstream.stream.flows.blockDataFlow
-import io.provenance.eventstream.stream.flows.pollingBlockDataFlow
-import io.provenance.eventstream.stream.kafkaBlockSink
-import io.provenance.eventstream.stream.kafkaBlockSource
-import io.provenance.eventstream.stream.models.StreamBlockImpl
-import io.provenance.eventstream.stream.models.extensions.blockEvents
-import io.provenance.eventstream.stream.models.extensions.dateTime
-import io.provenance.eventstream.stream.models.extensions.txData
-import io.provenance.eventstream.stream.models.extensions.txErroredEvents
-import io.provenance.eventstream.stream.models.extensions.txEvents
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collect
@@ -23,6 +10,19 @@ import kotlinx.coroutines.withContext
 import org.apache.kafka.clients.CommonClientConfigs
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.producer.ProducerConfig
+import tech.figure.eventstream.decodeBase64
+import tech.figure.eventstream.decoder.moshiDecoderAdapter
+import tech.figure.eventstream.net.okHttpNetAdapter
+import tech.figure.eventstream.stream.flows.blockDataFlow
+import tech.figure.eventstream.stream.flows.pollingBlockDataFlow
+import tech.figure.eventstream.stream.kafkaBlockSink
+import tech.figure.eventstream.stream.kafkaBlockSource
+import tech.figure.eventstream.stream.models.StreamBlockImpl
+import tech.figure.eventstream.stream.models.blockEvents
+import tech.figure.eventstream.stream.models.dateTime
+import tech.figure.eventstream.stream.models.txData
+import tech.figure.eventstream.stream.models.txErroredEvents
+import tech.figure.eventstream.stream.models.txEvents
 
 suspend fun main() {
     // the topic to publish to/read from, can override if needed. The default will work with the docker-compose setup

--- a/event-stream-example/src/main/kotlin/io/provenance/example/SimpleEventStreamListener.kt
+++ b/event-stream-example/src/main/kotlin/io/provenance/example/SimpleEventStreamListener.kt
@@ -1,14 +1,14 @@
 package io.provenance.example
 
-import io.provenance.eventstream.decoder.moshiDecoderAdapter
-import io.provenance.eventstream.extensions.decodeBase64
-import io.provenance.eventstream.net.okHttpNetAdapter
-import io.provenance.eventstream.stream.flows.blockDataFlow
-import io.provenance.eventstream.stream.flows.pollingBlockDataFlow
-import io.provenance.eventstream.stream.models.extensions.dateTime
-import io.provenance.eventstream.stream.models.extensions.txData
-import io.provenance.eventstream.stream.models.extensions.txEvents
 import kotlinx.coroutines.flow.collect
+import tech.figure.eventstream.decodeBase64
+import tech.figure.eventstream.decoder.moshiDecoderAdapter
+import tech.figure.eventstream.net.okHttpNetAdapter
+import tech.figure.eventstream.stream.flows.blockDataFlow
+import tech.figure.eventstream.stream.flows.pollingBlockDataFlow
+import tech.figure.eventstream.stream.models.dateTime
+import tech.figure.eventstream.stream.models.txData
+import tech.figure.eventstream.stream.models.txEvents
 
 val EVENTS = listOf("wasm")
 


### PR DESCRIPTION
# Description
Figure Tech has published a more polished, public event stream lib after migrating the library from provenance. This upgrades the event stream example's code to use it.