### PR TITLE
Piercetrey figure/include request query scope

### DIFF
--- a/p8e-contract-sdk-example/application/src/main/kotlin/io/p8e/demo/Main.kt
+++ b/p8e-contract-sdk-example/application/src/main/kotlin/io/p8e/demo/Main.kt
@@ -98,6 +98,7 @@ fun loadScope(scopeUuid: UUID): ScopeResponse =
         scopeId = scopeUuid.toString()
         includeSessions = true
         includeRecords = true
+        includeRequest = true
     }.let { request ->
         pbcClient.metadataClient.withDeadlineAfter(10, TimeUnit.SECONDS).scope(request)
     }

--- a/p8e-contract-sdk-example/build.gradle.kts
+++ b/p8e-contract-sdk-example/build.gradle.kts
@@ -4,7 +4,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     kotlin("jvm") version "1.9.21"
-    id("io.provenance.p8e.p8e-publish") version "0.8.1"
+    id("io.provenance.p8e.p8e-publish") version "0.8.2"
 }
 
 repositories {
@@ -38,6 +38,7 @@ p8e {
         "local" to P8eLocationExtension().also {
             it.osUrl = System.getenv("OS_GRPC_URL")
             it.provenanceUrl = System.getenv("PROVENANCE_GRPC_URL")
+            it.provenanceQueryTimeoutSeconds = "20"
             it.encryptionPrivateKey = System.getenv("ENCRYPTION_PRIVATE_KEY")
             it.signingPrivateKey = System.getenv("SIGNING_PRIVATE_KEY")
             it.chainId = System.getenv("CHAIN_ID")


### PR DESCRIPTION
* Set includeRequest flag when loading scope
  - Provenance 1.17.0 stopped including the request that produced the scope response by default, which breaks some scope sdk validation when hydrating records (validates that the records were requested, to disambiguate between a scope with no records, and one where records simply weren't requested)
* update p8e-publish to 0.8.2 and set higher query timeout